### PR TITLE
feature/effect-failure-mapping-and-assertion

### DIFF
--- a/packages/fabric/core/effect/effect.test.ts
+++ b/packages/fabric/core/effect/effect.test.ts
@@ -398,4 +398,25 @@ describe("Effect", () => {
     expect(result.unwrapErrorOrThrow()).toBeInstanceOf(UnexpectedError);
     expect(result.unwrapErrorOrThrow().message).toBe("original failure");
   });
+
+  test("Effect.errorMap should map an error to a new error", async () => {
+    const effect = Effect.failWith(new UnexpectedError("failure")).mapError(
+      (err) => new UnexpectedError(`mapped: ${err.message}`),
+    );
+    const result = await effect.run();
+    expect(result.isError()).toBe(true);
+    expect(result.unwrapErrorOrThrow()).toBeInstanceOf(UnexpectedError);
+    expect(result.unwrapErrorOrThrow().message).toBe("mapped: failure");
+  });
+
+  test("Effect.errorMap should not affect a successful Result", async () => {
+    const effect: Effect<number, UnexpectedError> = Effect.from(() => 42);
+
+    const mappedEffect = effect.mapError(
+      (err) => new UnexpectedError(`mapped: ${err.message}`),
+    );
+    const result = await mappedEffect.run();
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrapOrThrow()).toBe(42);
+  });
 });

--- a/packages/fabric/core/effect/effect.test.ts
+++ b/packages/fabric/core/effect/effect.test.ts
@@ -370,4 +370,32 @@ describe("Effect", () => {
     expect(result.unwrapErrorOrThrow()).toBeInstanceOf(UnexpectedError);
     expect(result.unwrapErrorOrThrow().message).toBe("unexpected failure");
   });
+
+  test("Effect.assertOrFail should return a successful Result if the assertion passes", async () => {
+    const effect = Effect.ok(42).assertOrFail(() =>
+      Effect.fromResult(() => Result.ok())
+    );
+    const result = await effect.run();
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrapOrThrow()).toBe(42);
+  });
+
+  test("Effect.assertOrFail should return a failed Result if the assertion fails", async () => {
+    const effect = Effect.ok(42).assertOrFail(() =>
+      Effect.failWith(new UnexpectedError("failure"))
+    );
+    const result = await effect.run();
+    expect(result.isError()).toBe(true);
+    expect(result.unwrapErrorOrThrow()).toBeInstanceOf(UnexpectedError);
+    expect(result.unwrapErrorOrThrow().message).toBe("failure");
+  });
+
+  test("Effect.assertOrFail should return a failed Result if the original effect returns an error", async () => {
+    const effect = Effect.failWith(new UnexpectedError("original failure"))
+      .assertOrFail(() => Effect.ok());
+    const result = await effect.run();
+    expect(result.isError()).toBe(true);
+    expect(result.unwrapErrorOrThrow()).toBeInstanceOf(UnexpectedError);
+    expect(result.unwrapErrorOrThrow().message).toBe("original failure");
+  });
 });

--- a/packages/fabric/core/effect/effect.ts
+++ b/packages/fabric/core/effect/effect.ts
@@ -174,6 +174,18 @@ export class Effect<
     return this.flatMap((value) => fn(value).map(() => value));
   }
 
+  mapError<TNewError extends TaggedError>(
+    fn: (error: TError) => MaybePromise<TNewError>,
+  ): Effect<TValue, TNewError, TDeps> {
+    return new Effect(async (deps: TDeps) => {
+      const result = await this.fn(deps);
+      if (result.isOk()) {
+        return result;
+      }
+      return Result.failWith(await fn(result.value as TError));
+    });
+  }
+
   // deno-fmt-ignore
   static seq<
     T1,TE1 extends TaggedError,

--- a/packages/fabric/core/effect/effect.ts
+++ b/packages/fabric/core/effect/effect.ts
@@ -168,6 +168,12 @@ export class Effect<
     return (await this.fn(deps)).unwrapErrorOrThrow();
   }
 
+  assertOrFail<TNewError extends TaggedError, TNewDeps = void>(
+    fn: (v: TValue) => Effect<void, TNewError, TNewDeps>,
+  ): Effect<TValue, TError | TNewError, MergeTypes<TDeps, TNewDeps>> {
+    return this.flatMap((value) => fn(value).map(() => value));
+  }
+
   // deno-fmt-ignore
   static seq<
     T1,TE1 extends TaggedError,


### PR DESCRIPTION
Add mapError method to map the error of an effect into some other error type
Add assertOrFail method to assert the result of an effect and continue with the happy path or fail with the assertion error.